### PR TITLE
CLI Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.1"
 edition = "2021"
 authors = [ "Joshua Winters-Brown" ]
 readme = "README.md"
+description = "Automatically collect device information on run, and insert it into the registry of the device."
 repository = "https://github.com/ofgrenudo/tattoo"
 license-file = "LICENSE.md"
 
@@ -12,6 +13,7 @@ name = "tattoo_lib"
 path = "src/lib.rs"
 
 [dependencies]
+clap = { version = "4.3.21", features = ["derive"] }
 native-windows-derive = "1.0.5"
 native-windows-gui = "1.0.13"
 winreg = "0.50.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tattoo"
-version = "0.4.1"
+version = "0.4.3"
 edition = "2021"
 authors = [ "Joshua Winters-Brown" ]
 readme = "README.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,42 @@
-mod ui;
+use clap::Parser;
+use tattoo_lib::{*};
+
+#[derive(Parser, Debug)]
+#[command(
+    author = env!("CARGO_PKG_AUTHORS"),
+    version = env!("CARGO_PKG_VERSION"),
+    about = env!("CARGO_PKG_DESCRIPTION"),
+)]
+
+// todo!() need to research into making an option be either true or false, if true contain a value
+struct Args {
+    #[arg(short, long, default_value_t=false)]
+    serial_number: bool,
+
+    #[arg(long, default_value_t=false)]
+    make: bool,
+
+    #[arg(long, default_value_t=false)]
+    model: bool,
+
+    #[arg(short, long, default_value_t=false)]
+    asset_tag: bool,
+
+    #[arg(short, long, default_value_t=false)]
+    update: bool,
+}
 
 fn main() {
-    ui::begin_ui();
+    let args = Args::parse();
+    //println!("{:?}", args); // This is a nice way to debug when adding new commands
+    
+    // we want to update first, before printing out device information this is currently a todo!()
+    if args.update { println!("Update is true, update information automatically using tattoo features."); }
+    if args.make { println!("Make: {}", device::make::get()); }
+    if args.model { println!("Model: {}", device::model::get()); }
+    if args.serial_number { println!("Serial Number: {}", device::serialnumber::get()); }
+    if args.asset_tag { println!("Asset Tag: {}", registry::assettag::get()); }
+    
+    // This is our default behavoiur, what will we do. Basically, since all values are default we will take the inverse of that. If any one value is set to true, then it will become false and this will nto run.
+    if !(args.serial_number || args.make || args.model || args.asset_tag || args.asset_tag) { println!("Make: {}\nModel: {}\nSerial Number: {}\nAsset Tag: {}", device::make::get(), device::model::get(), device::serialnumber::get(), registry::assettag::get()); }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,42 +1,72 @@
 use clap::Parser;
-use tattoo_lib::{*};
-
-#[derive(Parser, Debug)]
-#[command(
-    author = env!("CARGO_PKG_AUTHORS"),
-    version = env!("CARGO_PKG_VERSION"),
-    about = env!("CARGO_PKG_DESCRIPTION"),
-)]
+use tattoo_lib::{device, registry};
 
 // todo!() need to research into making an option be either true or false, if true contain a value
+#[derive(Parser, Debug)]
+#[command(author = env!("CARGO_PKG_AUTHORS"), version = env!("CARGO_PKG_VERSION"), about = env!("CARGO_PKG_DESCRIPTION"))]
 struct Args {
-    #[arg(short, long, default_value_t=false)]
-    serial_number: bool,
-
-    #[arg(long, default_value_t=false)]
+    #[arg(long, help = "Returns the computer make", default_value_t = false)]
     make: bool,
 
-    #[arg(long, default_value_t=false)]
+    #[arg(long, help = "Returns the computer model", default_value_t = false)]
     model: bool,
 
-    #[arg(short, long, default_value_t=false)]
+    #[arg(
+        long,
+        help = "Returns the computer serial number",
+        default_value_t = false
+    )]
+    serial_number: bool,
+
+    #[arg(long, help = "Returns the defined asset tag", default_value_t = false)]
     asset_tag: bool,
 
-    #[arg(short, long, default_value_t=false)]
+    #[arg(long, help = "Assigns the asset tag")]
+    set_asset_tag: Option<String>,
+
+    #[arg(
+        long,
+        help = "Updates hardware values into the registry (must be ran as administrator)",
+        default_value_t = false
+    )]
     update: bool,
 }
 
 fn main() {
     let args = Args::parse();
     //println!("{:?}", args); // This is a nice way to debug when adding new commands
-    
-    // we want to update first, before printing out device information this is currently a todo!()
-    if args.update { println!("Update is true, update information automatically using tattoo features."); }
-    if args.make { println!("Make: {}", device::make::get()); }
-    if args.model { println!("Model: {}", device::model::get()); }
-    if args.serial_number { println!("Serial Number: {}", device::serialnumber::get()); }
-    if args.asset_tag { println!("Asset Tag: {}", registry::assettag::get()); }
-    
-    // This is our default behavoiur, what will we do. Basically, since all values are default we will take the inverse of that. If any one value is set to true, then it will become false and this will nto run.
-    if !(args.serial_number || args.make || args.model || args.asset_tag || args.asset_tag) { println!("Make: {}\nModel: {}\nSerial Number: {}\nAsset Tag: {}", device::make::get(), device::model::get(), device::serialnumber::get(), registry::assettag::get()); }
+
+    if args.update {
+        registry::make::set(device::make::get());
+        registry::model::set(device::model::get());
+        registry::serialnumber::set(device::serialnumber::get());
+    }
+    if args.make {
+        println!("Make: {}", device::make::get());
+    }
+    if args.model {
+        println!("Model: {}", device::model::get());
+    }
+    if args.serial_number {
+        println!("Serial Number: {}", device::serialnumber::get());
+    }
+    if args.asset_tag {
+        println!("Asset Tag: {}", registry::assettag::get());
+    }
+
+    if args.set_asset_tag.is_some() {
+        registry::assettag::set(args.set_asset_tag.unwrap_or("".to_string()));
+    }
+
+    // This is our default behavoiur, what will we do. Basically, since all values are default we will take the inverse of that.
+    // If any one value is set to true, then it will become false and this will into run.
+    if !(args.serial_number || args.make || args.model || args.asset_tag) {
+        println!(
+            "Make: {}\nModel: {}\nSerial Number: {}\nAsset Tag: {}",
+            device::make::get(),
+            device::model::get(),
+            device::serialnumber::get(),
+            registry::assettag::get()
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,15 @@ struct Args {
     )]
     serial_number: bool,
 
-    #[arg(long, help = "Returns the defined asset tag", default_value_t = false)]
-    asset_tag: bool,
+    #[arg(
+        long = "asset-tag",
+        help = "Returns the defined asset tag",
+        default_value_t = false
+    )]
+    get_asset_tag: bool,
 
-    #[arg(long, help = "Assigns the asset tag")]
-    set_asset_tag: Option<String>,
+    #[arg(long = "set-asset-tag", help = "Assigns the asset tag")]
+    asset_tag: Option<String>,
 
     #[arg(
         long,
@@ -50,17 +54,17 @@ fn main() {
     if args.serial_number {
         println!("Serial Number: {}", device::serialnumber::get());
     }
-    if args.asset_tag {
+    if args.get_asset_tag {
         println!("Asset Tag: {}", registry::assettag::get());
     }
 
-    if args.set_asset_tag.is_some() {
-        registry::assettag::set(args.set_asset_tag.unwrap_or("".to_string()));
+    if args.asset_tag.is_some() {
+        registry::assettag::set(args.asset_tag.unwrap_or("".to_string()));
     }
 
     // This is our default behavoiur, what will we do. Basically, since all values are default we will take the inverse of that.
     // If any one value is set to true, then it will become false and this will into run.
-    if !(args.serial_number || args.make || args.model || args.asset_tag) {
+    if !(args.serial_number || args.make || args.model || args.get_asset_tag) {
         println!(
             "Make: {}\nModel: {}\nSerial Number: {}\nAsset Tag: {}",
             device::make::get(),

--- a/src/registry/assettag.rs
+++ b/src/registry/assettag.rs
@@ -13,9 +13,11 @@ use winreg::RegKey;
 /// 
 pub fn get() -> String {
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo").expect("");
+    let cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo");
 
-    let asset_tag = cur_ver.get_value("asset_tag").unwrap_or("".to_string());
+    let mut asset_tag: String = String::from("");
+    if cur_ver.is_err() { asset_tag = String::from("Error, unable to open registry, please run as administrator."); }
+    if cur_ver.is_ok() { asset_tag = cur_ver.unwrap().get_value("asset_tag").unwrap_or("".to_string()); }
 
     asset_tag
 }

--- a/src/registry/assettag.rs
+++ b/src/registry/assettag.rs
@@ -3,44 +3,51 @@ use winreg::enums::*;
 use winreg::RegKey;
 
 /// This function returns a string. It works by contacting a predefined registry path `HKLM:\Software\Tattoo\asset_tag`
-/// 
+///
 /// # Examples
 /// ```rust,ignore
 /// use tattoo_lib::registry;
-/// 
+///
 /// let asset_tag: String = registry::assettag::get();
 /// ```
-/// 
+///
 pub fn get() -> String {
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo");
 
     let mut asset_tag: String = String::from("");
-    if cur_ver.is_err() { asset_tag = String::from("Error, unable to open registry, please run as administrator."); }
-    if cur_ver.is_ok() { asset_tag = cur_ver.unwrap().get_value("asset_tag").unwrap_or("".to_string()); }
+    if cur_ver.is_err() {
+        asset_tag = String::from("Error, unable to open registry, please run as administrator.");
+    }
+    if cur_ver.is_ok() {
+        asset_tag = cur_ver
+            .unwrap()
+            .get_value("asset_tag")
+            .unwrap_or("".to_string());
+    }
 
     asset_tag
 }
 
 /// This function takes a `String` as an input and will use it to set the value in the registry.
-/// 
+///
 /// ## Example Usage
-/// 
+///
 /// ```rust,ignore
 /// use tattoo_lib::registry;
-/// 
+///
 /// registry::assettag::set("98513279");
 /// ```
-/// 
+///
 pub fn set(key_value: String) {
     let key_name = "asset_tag";
 
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let _cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo").expect("Unable to open Tattoo Directory");
-
     let path = Path::new("Software").join("Tattoo");
-    let (key, _disp) = hklm.create_subkey(&path).expect("Unable to create new key!");
-    
+    let (key, _disp) = hklm
+        .create_subkey(&path)
+        .expect("Unable to create new key!");
+
     key.delete_value(key_name).unwrap_or(());
 
     // match disp {
@@ -48,5 +55,6 @@ pub fn set(key_value: String) {
     //     REG_OPENED_EXISTING_KEY => println!("An existing key has been opened"),
     // }
 
-    key.set_value(key_name, &key_value).expect("Could not create key!");
+    key.set_value(key_name, &key_value)
+        .expect("Could not create key!");
 }

--- a/src/registry/make.rs
+++ b/src/registry/make.rs
@@ -3,14 +3,14 @@ use winreg::enums::*;
 use winreg::RegKey;
 
 /// This function returns a string. It works by contacting a predefined registry path `HKLM:\Software\Tattoo\make`
-/// 
+///
 /// # Examples
 /// ```rust,ignore
 /// use tattoo_lib::registry;
-/// 
+///
 /// let make: String = registry::make::get();
 /// ```
-/// 
+///
 pub fn get() -> String {
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo").expect("");
@@ -21,25 +21,24 @@ pub fn get() -> String {
 }
 
 /// This function takes a `String` as an input and will use it to set the value in the registry.
-/// 
+///
 /// ## Example Usage
-/// 
+///
 /// ```rust,ignore
 /// use tattoo_lib::registry;
-/// 
+///
 /// registry::make::set("Dell");
 /// ```
-/// 
+///
 pub fn set(key_value: String) {
     let key_name = "manufacturer";
 
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let _cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo").expect("Unable to open Tattoo Directory");
-
-
     let path = Path::new("Software").join("Tattoo");
-    let (key, _disp) = hklm.create_subkey(&path).expect("Unable to create new key!");
-    
+    let (key, _disp) = hklm
+        .create_subkey(&path)
+        .expect("Unable to create new key!");
+
     key.delete_value(key_name).unwrap_or(());
 
     // match disp {
@@ -47,5 +46,6 @@ pub fn set(key_value: String) {
     //     REG_OPENED_EXISTING_KEY => println!("An existing key has been opened"),
     // }
 
-    key.set_value(key_name, &key_value).expect("Could not create key!");
+    key.set_value(key_name, &key_value)
+        .expect("Could not create key!");
 }

--- a/src/registry/serialnumber.rs
+++ b/src/registry/serialnumber.rs
@@ -3,14 +3,14 @@ use winreg::enums::*;
 use winreg::RegKey;
 
 /// This function returns a string. It works by contacting a predefined registry path `HKLM:\Software\Tattoo\serial_number`
-/// 
+///
 /// # Examples
 /// ```rust,ignore
 /// use tattoo_lib::registry;
-/// 
+///
 /// let serial_number: String = registry::serialnumber::get();
 /// ```
-/// 
+///
 pub fn get() -> String {
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo").expect("");
@@ -21,25 +21,24 @@ pub fn get() -> String {
 }
 
 /// This function takes a `String` as an input and will use it to set the value in the registry.
-/// 
+///
 /// ## Example Usage
-/// 
+///
 /// ```rust,ignore
 /// use tattoo_lib::registry;
-/// 
+///
 /// registry::serialnumber::set("fadsf78sdf6sav57a");
 /// ```
-/// 
+///
 pub fn set(key_value: String) {
-    let key_name= "serial_number";
+    let key_name = "serial_number";
 
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let _cur_ver = hklm.open_subkey("SOFTWARE\\Tattoo").expect("Unable to open Tattoo Directory");
-
-
     let path = Path::new("Software").join("Tattoo");
-    let (key, _disp) = hklm.create_subkey(&path).expect("Unable to create new key!");
-    
+    let (key, _disp) = hklm
+        .create_subkey(&path)
+        .expect("Unable to create new key!");
+
     key.delete_value(key_name).unwrap_or(());
 
     // match disp {
@@ -47,5 +46,6 @@ pub fn set(key_value: String) {
     //     REG_OPENED_EXISTING_KEY => println!("An existing key has been opened"),
     // }
 
-    key.set_value(key_name, &key_value).expect("Could not create key!");
+    key.set_value(key_name, &key_value)
+        .expect("Could not create key!");
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,6 +7,7 @@ use tattoo_lib::device;
 use tattoo_lib::registry;
 
 #[derive(Default, NwgUi)]
+#[depreciated]
 pub struct TattooUI {
     #[nwg_control(size: (300, 230), position: (300, 300), title: "Tattoo")]
     #[nwg_events( OnWindowClose: [TattooUI::safely_exit] )]
@@ -41,6 +42,7 @@ pub struct TattooUI {
     commit: nwg::Button,
 }
 
+#[depreciated]
 impl TattooUI {
     fn confirm_input(&self) {
         registry::assettag::set(self.get_asset_tag());
@@ -92,6 +94,7 @@ impl TattooUI {
 
 }
 
+#[depreciated]
 pub fn begin_ui() {
     let mut _asset_tag = "".to_string();
     let mut _manufacturer = "".to_string();

--- a/tattoo.exe.manifest
+++ b/tattoo.exe.manifest
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity
-    version="1.0.0.0"
-    processorArchitecture="*"
-    name="app"
-    type="win32"
-/>
-<dependency>
-    <dependentAssembly>
-        <assemblyIdentity
-            type="win32"
-            name="Microsoft.Windows.Common-Controls"
-            version="6.0.0.0"
-            processorArchitecture="*"
-            publicKeyToken="6595b64144ccf1df"
-            language="*"
-        />
-    </dependentAssembly>
-</dependency>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"> 
+  <assemblyIdentity version="1.0.0.0"
+     processorArchitecture="X86"
+	     name="Tattoo"
+	     type="win32"/> 
+  <description>Manage and store information into device registry</description> 
+  <!-- Identify the application security requirements. -->
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel
+					level="requireAdministrator"
+					uiAccess="false"/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
 </assembly>


### PR DESCRIPTION
The Tattoo module has undergone a complete rewrite, now utilizing the CLAP crate for streamlined command line argument parsing as recommended by issue #4. This modification is poised to significantly enhance integration capabilities with MECM and various scripting tools. Looking ahead, I am planning to explore the development of a graphical user interface (GUI) that will complement the existing CLI interface.

# Sample Output

Provided below is a preview of the command's output when executed. Presently, it encompasses all functionalities present in the previous win32 application. Notably, manual manipulation of make, model, and serial number data by end users will not be accommodated. The sole editable input is the asset tag value, as it remains a piece of information not easily generated by the computer.

Several forthcoming commands will include:

- `--verbose` for the display of detailed logging information
- `--log <LOG_FILE>` for the archival of log file details

```txt
Automated compilation of device details during runtime, seamlessly inserted into the device's registry.

Usage: tattoo.exe [OPTIONS]

Options:
      --make                       Retrieve computer make
      --model                      Retrieve computer model
      --serial-number              Retrieve computer serial number
      --asset-tag                  Retrieve predefined asset tag
      --set-asset-tag <ASSET_TAG>  Assign a new asset tag
      --update                     Update hardware information in the registry (requires administrator privileges)
  -h, --help                       Display help
  -V, --version                    Display version
```

Your feedback on these changes would be greatly appreciated.